### PR TITLE
Fix free list index bug

### DIFF
--- a/impl/handle_map-inl.h
+++ b/impl/handle_map-inl.h
@@ -118,7 +118,7 @@ namespace griffin {
 		}
 
 		// remove the component by swapping with the last element, then pop_back
-		if (m_items.size() > 1) {
+		if (innerIndex != m_items.size() - 1) {
 			std::swap(m_items.at(innerIndex), m_items.back());
 			std::swap(m_meta.at(innerIndex), m_meta.back());
 


### PR DESCRIPTION
If the item happened to already be at the last index, the index assignment in this branch (line 126) would stomp the free list assignment from line 116.

This fix works fine on my side but I edited through the GitHub website and I haven't run any test cases (does this project have test cases?) so you should probably test it on your own before taking this.